### PR TITLE
feat: add deprecation warning for list format config

### DIFF
--- a/internal/cb/cb_test.go
+++ b/internal/cb/cb_test.go
@@ -392,14 +392,14 @@ func Test_DumpConfig(t *testing.T) {
 			args:            args{"testdata/_test_dump_notfound.yaml"},
 			want:            "",
 			wantErr:         true,
-			wantErrContains: "failed to read config file for dump",
+			wantErrContains: "no such file or directory",
 		},
 		{
 			name:            "invalid yaml syntax",
 			args:            args{"testdata/_test_invalid_syntax_dump.yaml"},
 			want:            "",
 			wantErr:         true,
-			wantErrContains: "failed to unmarshal yaml for dump",
+			wantErrContains: "failed to unmarshal yaml",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Add deprecation warning when list format is used in config files to encourage migration to map format.

- Display warning message with emoji to stderr for better visibility
- Update DumpConfig to use ReadConfigFile to ensure warning is shown
- Fix test expectations for updated error messages

🤖 Generated with [Claude Code](https://claude.ai/code)