### PR TITLE
fix: replace deprecated brews with homebrew_casks in goreleaser config

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -47,7 +47,7 @@ changelog:
       - Merge remote-tracking branch
       - Merge branch
       - go mod tidy
-brews:
+homebrew_casks:
   - repository:
       owner: koh-sh
       name: homebrew-tap

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is a simple CLI tool to "Start build with overrides" multiple AWS CodeBuild
 You can install with Homebrew.
 
 ```bash
-brew install koh-sh/tap/codebuild-multirunner
+brew install --cask koh-sh/tap/codebuild-multirunner
 ```
 
 Or download prebuild binary from [Releases](https://github.com/koh-sh/codebuild-multirunner/releases)


### PR DESCRIPTION
- Replace deprecated 'brews' with 'homebrew_casks' configuration
- Update README installation instructions to use --cask flag

🤖 Generated with [Claude Code](https://claude.ai/code)