### PR TITLE
fix: add post-install hook to remove macOS quarantine bit from homebr…

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -52,6 +52,12 @@ homebrew_casks:
       owner: koh-sh
       name: homebrew-tap
       token: "{{ .Env.PAT }}"
+    hooks:
+      post:
+        install: |
+          if system_command("/usr/bin/xattr", args: ["-h"]).exit_status == 0
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/{{ .ProjectName }}"]
+          end
 # The lines beneath this are called `modelines`. See `:help modeline`
 # Feel free to remove those if you don't want/use them.
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json


### PR DESCRIPTION
…ew cask

Add post-install hook to homebrew_casks configuration to automatically remove the macOS quarantine bit, preventing "app is damaged" errors during installation.

🤖 Generated with [Claude Code](https://claude.ai/code)