### PR TITLE
chore: upgrade Go version to 1.25.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-alpine AS build-stage
+FROM golang:1.25.1-alpine AS build-stage
 WORKDIR /app
 COPY . /app/
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ COVFILE = coverage.out
 COVHTML = cover.html
 
 test:
-	go test ./... -json | tparse -all
+	go test ./... -json | go tool tparse -all
 
 fmt:
 	go tool gofumpt -l -w .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/koh-sh/codebuild-multirunner
 
-go 1.24.0
+go 1.25.1
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.38.1


### PR DESCRIPTION
- Update go.mod from Go 1.24.0 to 1.25.1
- Update Dockerfile base image to golang:1.25.1-alpine
- Fix Makefile to use 'go tool tparse' instead of direct tparse command

🤖 Generated with [Claude Code](https://claude.ai/code)